### PR TITLE
addCustomWord

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,11 @@
           "description": "Highlight color words in all files (grey, green, etc.)",
           "type": "boolean"
         },
+        "color-highlight.customWords": {
+          "default": {},
+          "description": "add the color name and code you want",
+          "type": "object"
+        },
         "color-highlight.markerType": {
           "default": "background",
           "description": "Style of the highlight. Can be 'dot-before', 'dot-after', 'foreground', 'background', 'outline', 'underline'",

--- a/src/color-highlight.js
+++ b/src/color-highlight.js
@@ -13,7 +13,7 @@ import { findCssVars } from './strategies/css-vars';
 import { findFn } from './strategies/functions';
 import { findHex } from './strategies/hex';
 import { findHwb } from './strategies/hwb';
-import { findWords } from './strategies/words';
+import { findWords, addCustomWord } from './strategies/words';
 import { DecorationMap } from './lib/decoration-map';
 import { dirname } from 'path';
 
@@ -35,7 +35,11 @@ export class DocumentHighlight {
     this.strategies = [findHex, findFn, findHwb];
 
     if (colorWordsLanguages.indexOf(colorWordsLanguages) > -1 || viewConfig.matchWords) {
-      this.strategies.push(findWords);
+      const customWords = viewConfig.customWords;
+      if (Object.entries(customWords).length !== 0){
+        addCustomWord(customWords);
+      }
+      this.strategies.push(text => findWords(text,customWords));
     }
 
     switch (document.languageId) {

--- a/src/strategies/words.js
+++ b/src/strategies/words.js
@@ -1,43 +1,12 @@
 const Color = require('color');
 const webColors = require('color-name');
 
-const customColors = {
-  RED: '#EA5455',
-  BLUE: '#4FCBFF',
-  NIGHT: '#e5cdb3',
-  GRAY_LV0: '#fff',
-  GRAY_LV1: '#f9f9f9',
-  GRAY_LV2: '#e3e3e3',
-  GRAY_LV25: '#d2d2d2',
-  GRAY_LV3: '#b7b7b7',
-  GRAY_LV4: '#909090',
-  GRAY_LV5: '#626262',
-  GRAY_LV6: '#4e4e4e',
-  GRAY_LV7: '#2E2E2E',
-};
-
 let preparedRePart = Object.keys(webColors)
   .map(color => `\\b${color}\\b`)
   .join('|');
 
- const customWord = ['RED',
-  'BLUE',
-  'NIGHT',
-  'GRAY_LV0',
-  'GRAY_LV1',
-  'GRAY_LV2',
-  'GRAY_LV25',
-  'GRAY_LV3',
-  'GRAY_LV4',
-  'GRAY_LV5',
-  'GRAY_LV6',
-  'GRAY_LV7',]
+let colorWeb = new RegExp('.?(' + preparedRePart + ')(?!-)', 'g');
 
-  customWord.forEach((word)=>{
-    preparedRePart = preparedRePart+'|\\b'+word+'\\b';
-  });
-
-const colorWeb = new RegExp('.?(' + preparedRePart + ')(?!-)', 'g');
 
 /**
  * @export
@@ -48,7 +17,7 @@ const colorWeb = new RegExp('.?(' + preparedRePart + ')(?!-)', 'g');
  *  color: string
  * }}
  */
-export async function findWords(text) {
+export async function findWords(text,customWords) {
   let match = colorWeb.exec(text);
   let result = [];
 
@@ -65,8 +34,8 @@ export async function findWords(text) {
 
     try {
       let color = null;
-      if (customWord.includes(matchedColor)){
-        color = customColors[matchedColor];
+      if (customWords.hasOwnProperty(matchedColor)){
+        color = customWords[matchedColor];
       }else{
       color = Color(matchedColor)
         .rgb()
@@ -82,4 +51,11 @@ export async function findWords(text) {
   }
 
   return result;
+}
+
+export function addCustomWord(customWords){
+  Object.keys(customWords).forEach((word)=>{
+    preparedRePart = preparedRePart+'|\\b'+word+'\\b';
+  });
+  colorWeb = new RegExp('.?(' + preparedRePart + ')(?!-)', 'g');
 }

--- a/src/strategies/words.js
+++ b/src/strategies/words.js
@@ -1,9 +1,44 @@
 const Color = require('color');
 const webColors = require('color-name');
 
-const preparedRePart = Object.keys(webColors)
+const customColors = {
+  RED: '#EA5455',
+  BLUE: '#4FCBFF',
+  NIGHT: '#e5cdb3',
+  GRAY_LV0: '#fff',
+  GRAY_LV1: '#f9f9f9',
+  GRAY_LV2: '#e3e3e3',
+  GRAY_LV25: '#d2d2d2',
+  GRAY_LV3: '#b7b7b7',
+  GRAY_LV4: '#909090',
+  GRAY_LV5: '#626262',
+  GRAY_LV6: '#4e4e4e',
+  GRAY_LV7: '#2E2E2E',
+};
+
+let preparedRePart = Object.keys(webColors)
   .map(color => `\\b${color}\\b`)
   .join('|');
+
+ const customWord = ['RED',
+  'BLUE',
+  'NIGHT',
+  'GRAY_LV0',
+  'GRAY_LV1',
+  'GRAY_LV2',
+  'GRAY_LV25',
+  'GRAY_LV3',
+  'GRAY_LV4',
+  'GRAY_LV5',
+  'GRAY_LV6',
+  'GRAY_LV7',]
+
+  customWord.forEach((word,index,array)=>{
+    preparedRePart = preparedRePart+'\\b'+word+'\\b';
+    if (!index === array.length - 1){ 
+      preparedRePart = preparedRePart + '|';
+    }
+  });
 
 const colorWeb = new RegExp('.?(' + preparedRePart + ')(?!-)', 'g');
 
@@ -32,17 +67,20 @@ export async function findWords(text) {
     }
 
     try {
-      const color = Color(matchedColor)
+      let color = null;
+      if (customWord.includes(matchedColor)){
+        color = customColors[matchedColor];
+      }else{
+      color = Color(matchedColor)
         .rgb()
         .string();
-
+      }
       result.push({
         start,
         end,
         color
       });
     } catch (e) { }
-
     match = colorWeb.exec(text);
   }
 

--- a/src/strategies/words.js
+++ b/src/strategies/words.js
@@ -33,11 +33,8 @@ let preparedRePart = Object.keys(webColors)
   'GRAY_LV6',
   'GRAY_LV7',]
 
-  customWord.forEach((word,index,array)=>{
-    preparedRePart = preparedRePart+'\\b'+word+'\\b';
-    if (!index === array.length - 1){ 
-      preparedRePart = preparedRePart + '|';
-    }
+  customWord.forEach((word)=>{
+    preparedRePart = preparedRePart+'|\\b'+word+'\\b';
   });
 
 const colorWeb = new RegExp('.?(' + preparedRePart + ')(?!-)', 'g');


### PR DESCRIPTION
When I use it in `var = hexCode` format
It's inconvenient not to see the color using real var
Added.
It works, but
I did not think about performance.
Please tell us if you have performance problems.


```
"color-highlight.customWords": {
   "customColor": "#fcfcfc",
   "customColor2": "rgb (252, 252, 252)"
}
```
Adding the same format works.